### PR TITLE
Fix submenu photo selection bug

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -809,6 +809,18 @@ async function handleOtherCallbacks(query) {
     
     // Callbacks pour l'ajout de photo au sous-menu
     else if (data === 'add_submenu_photo_yes') {
+        // Vérifier que les données nécessaires sont présentes
+        if (!state.submenuName || !state.submenuText || !state.serviceType) {
+            await sendOrEditMessage(
+                chatId,
+                '❌ Erreur: données du sous-menu perdues. Veuillez recommencer.',
+                [[{ text: '🔙 Retour', callback_data: 'admin_services' }]],
+                'HTML',
+                messageId
+            );
+            return;
+        }
+        
         userStates.set(userId, { ...state, state: 'adding_submenu_photo' });
         await sendOrEditMessage(
             chatId,
@@ -821,15 +833,23 @@ async function handleOtherCallbacks(query) {
     }
     
     else if (data === 'add_submenu_photo_no') {
+        // Vérifier que les données nécessaires sont présentes
+        if (!state.submenuName || !state.submenuText || !state.serviceType) {
+            await sendOrEditMessage(
+                chatId,
+                '❌ Erreur: données du sous-menu perdues. Veuillez recommencer.',
+                [[{ text: '🔙 Retour', callback_data: 'admin_services' }]],
+                'HTML',
+                messageId
+            );
+            return;
+        }
+        
         // Créer le sous-menu sans photo
         const fullServiceType = state.serviceType === 'liv' ? 'livraison' : 
                                state.serviceType === 'pos' ? 'postal' : 'meetup';
         
         await db.addSubmenu(fullServiceType, state.submenuName, state.submenuText, null);
-        delete state.state;
-        delete state.submenuName;
-        delete state.submenuText;
-        delete state.serviceType;
         
         await sendOrEditMessage(
             chatId,
@@ -1112,7 +1132,8 @@ bot.on('message', async (msg) => {
         // Sauvegarder le texte formaté
         const formattedText = parseMessageEntities(msg.text, msg.entities);
         state.submenuText = formattedText;
-        state.state = 'adding_submenu_photo_choice';
+        // Retirer l'état temporairement pour éviter que le bot pense encore attendre un texte
+        delete state.state;
         userStates.set(userId, state);
         
         // Demander si l'utilisateur veut ajouter une photo


### PR DESCRIPTION
Fix submenu creation flow when choosing to add a photo or not.

The bot's state was not correctly cleared after receiving the submenu description, leading to an incorrect prompt when selecting "Oui" or "Non" for a photo. This PR ensures the state is updated correctly and adds data integrity checks for submenu creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d179b68a-2d1a-449a-888f-67d11fbdfb91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d179b68a-2d1a-449a-888f-67d11fbdfb91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

